### PR TITLE
The ghost cli version will now also get bumps via update.sh

### DIFF
--- a/update.sh/vars.groovy
+++ b/update.sh/vars.groovy
@@ -24,6 +24,9 @@ def rawReposData = [
 	]],
 	['ghost', [
 		'env': 'GHOST_VERSION',
+		'otherEnvs': [
+			['ghost-cli', 'GHOST_CLI_VERSION'],
+		],
 	]],
 	['golang', [
 		'env': 'GOLANG_VERSION',


### PR DESCRIPTION
This should probably merge before https://github.com/docker-library/ghost/pull/68 merges.