### PR TITLE
Remove the update.sh job for nextcloud

### DIFF
--- a/update.sh/vars.groovy
+++ b/update.sh/vars.groovy
@@ -163,10 +163,6 @@ def rawReposData = [
 		'url': 'git@github.com:matomo-org/docker.git',
 		'env': 'MATOMO_VERSION',
 	]],
-	['nextcloud', [
-		'url': 'git@github.com:nextcloud/docker.git',
-		'env': 'NEXTCLOUD_VERSION',
-	]],
 	['rocket.chat', [
 		'url': 'git@github.com:RocketChat/Docker.Official.Image.git',
 		'env': 'RC_VERSION',


### PR DESCRIPTION
We are retiring @docker-library-bot in favor of @tilosp-bot