### PR TITLE
Move new jobs to an empty job

### DIFF
--- a/multiarch/empty-pipeline.groovy
+++ b/multiarch/empty-pipeline.groovy
@@ -1,0 +1,3 @@
+// properties are set via "generate-pipeline.groovy" (jobDsl)
+
+// This file is meant for build jobs that have transistioned to the new builder (so that trigger children can trigger an empty job)

--- a/multiarch/generate-pipeline.groovy
+++ b/multiarch/generate-pipeline.groovy
@@ -112,12 +112,15 @@ node {
 								<li><a href="https://github.com/docker-library/official-images/blob/master/library/${img}"><code>official-images/library/${img}</code></a></li>
 							</ul>
 						"""
-						groovyScript = 'multiarch/target-pipeline.groovy'
+						if (subset.contains(img)) {
+							groovyScript = 'multiarch/empty-pipeline.groovy'
+						} else {
+							groovyScript = 'multiarch/target-pipeline.groovy'
+						}
 					}
 
 					pipelineJob("${arch}/${img}") {
 						description(desc)
-						disabled(subset.contains(img))
 						logRotator { numToKeep(24) }
 						// TODO concurrentBuild(false)
 						// see https://issues.jenkins-ci.org/browse/JENKINS-31832?focusedCommentId=343307&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-343307


### PR DESCRIPTION
As a disabled job, it was breaking parent images because they fail to trigger children.