### PR TITLE
Add "worker" nodes to cleanup jobs

### DIFF
--- a/infra/vars.groovy
+++ b/infra/vars.groovy
@@ -10,7 +10,12 @@ archWorkers = [
 	'multiarch-ppc64le',
 	'multiarch-riscv64',
 	'multiarch-s390x',
+
 	'windows-2022',
+
+	'worker-01',
+	'worker-02',
+	'worker-03',
 ]
 
 // return "this" (for use via "load" in Jenkins pipeline, for example)


### PR DESCRIPTION
This applies the same logic we do to arch-specific workers to the generic workers, which isn't *exactly* right, but it's probably a close enough approximation to mostly work (and certainly better than them just filling up periodically until we clean them again).

This also adds cleaning of unused volumes and a TODO for cleaning of BASHBREW_CACHE (which is another "constantly growing" data store, but at a much smaller rate than images).