### PR TITLE
Fast fallback to IPv4 when IPv6 is slow

### DIFF
--- a/multiarch/empty-pipeline.groovy
+++ b/multiarch/empty-pipeline.groovy
@@ -40,7 +40,7 @@ node {
 				fi
 
 				# https://doi-janky.infosiftr.net/job/wip/job/crane
-				wget -O "crane$ext" "https://doi-janky.infosiftr.net/job/wip/job/crane/lastSuccessfulBuild/artifact/crane-$BASHBREW_ARCH$ext" --progress=dot:giga
+				wget --timeout=5 -O "crane$ext" "https://doi-janky.infosiftr.net/job/wip/job/crane/lastSuccessfulBuild/artifact/crane-$BASHBREW_ARCH$ext" --progress=dot:giga
 				# TODO checksum verification ("checksums.txt")
 				chmod +x "crane$ext"
 				"./crane$ext" version

--- a/multiarch/external-pins-trigger-pipeline.groovy
+++ b/multiarch/external-pins-trigger-pipeline.groovy
@@ -64,7 +64,7 @@ node(vars.node(env.ACT_ON_ARCH, 'external-pins-trigger')) {
 						if (0 != sh(returnStatus: true, script: '''#!/usr/bin/env bash
 							set -Eeuo pipefail
 							set -x
-							commit="$(wget -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$CHILD/lastSuccessfulBuild/artifact/build-info/commit.txt")"
+							commit="$(wget --timeout=5 -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$CHILD/lastSuccessfulBuild/artifact/build-info/commit.txt")"
 							[ -n "$commit" ]
 							file="$(.external-pins/file.sh "$PIN")"
 							[ -s "$file" ]

--- a/multiarch/target-pipeline.groovy
+++ b/multiarch/target-pipeline.groovy
@@ -121,7 +121,7 @@ node(vars.node(env.ACT_ON_ARCH, env.ACT_ON_IMAGE)) {
 						fi
 
 						parentRepo="${parent%%:*}"
-						parentImageId="$(wget -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$parentRepo/lastSuccessfulBuild/artifact/build-info/image-ids/${parent//:/_}.txt" 2>/dev/null || :)"
+						parentImageId="$(wget --timeout=5 -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$parentRepo/lastSuccessfulBuild/artifact/build-info/image-ids/${parent//:/_}.txt" 2>/dev/null || :)"
 						if [ -z "$parentImageId" ]; then
 							# we can't tell if it's fresh; pull it
 							parentsToPull+=( "$parent" )

--- a/multiarch/trigger-pipeline.groovy
+++ b/multiarch/trigger-pipeline.groovy
@@ -54,7 +54,9 @@ node(vars.node(env.ACT_ON_ARCH, 'trigger')) {
 		if (0 != sh(returnStatus: true, script: '''#!/usr/bin/env bash
 			set -Eeuo pipefail
 			set -x
-			commit="$(wget -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$REPO/lastSuccessfulBuild/artifact/build-info/commit.txt")"
+
+			# ipv6 can be extremely slow on s390x so set a timeout and have wget try the other DNS addresses instead
+			commit="$(wget --timeout=5 -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$ACT_ON_ARCH/job/$REPO/lastSuccessfulBuild/artifact/build-info/commit.txt")"
 			[ -n "$commit" ]
 			touchingCommits="$(git -C "$BASHBREW_LIBRARY" log --oneline "$commit...HEAD" -- "$REPO")"
 			[ -z "$touchingCommits" ]

--- a/reports/failing-tags-pipeline.groovy
+++ b/reports/failing-tags-pipeline.groovy
@@ -56,7 +56,7 @@ node {
 			failingTags=()
 			declare -A failingTagArches=()
 			for arch in $arches; do
-				tags="$(wget -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$arch/job/$repo/lastSuccessfulBuild/artifact/build-info/failed.txt" || :)"
+				tags="$(wget --timeout=5 -qO- "https://doi-janky.infosiftr.net/job/multiarch/job/$arch/job/$repo/lastSuccessfulBuild/artifact/build-info/failed.txt" || :)"
 				[ -n "$tags" ] || continue
 				IFS=$'\\n'; tags=( $tags ); unset IFS
 

--- a/tianon/debian-eol-pipeline.groovy
+++ b/tianon/debian-eol-pipeline.groovy
@@ -30,10 +30,10 @@ node() {
 		deleteDir()
 		stage('Download debuerreotype') {
 			sh '''
-				wget -O 'debuerreotype.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeVersion}.tar.gz"
+				wget --timeout=5 -O 'debuerreotype.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeVersion}.tar.gz"
 				tar -xf debuerreotype.tgz --strip-components=1
 				if [ "$debuerreotypeExamplesCommit" != "$debuerreotypeVersion" ]; then
-					wget -O 'debuerreotype-examples.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeExamplesCommit}.tar.gz"
+					wget --timeout=5 -O 'debuerreotype-examples.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeExamplesCommit}.tar.gz"
 					rm -rf examples
 					tar -xf debuerreotype-examples.tgz --strip-components=1 \
 						"debuerreotype-${debuerreotypeExamplesCommit}/.docker-image.sh" \

--- a/tianon/debuerreotype/arch-pipeline.groovy
+++ b/tianon/debuerreotype/arch-pipeline.groovy
@@ -54,10 +54,10 @@ node(multiarchVars.node(env.BUILD_ARCH, env.ACT_ON_IMAGE)) {
 			deleteDir()
 			stage('Download') {
 				sh '''
-					wget -O 'debuerreotype.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeVersion}.tar.gz"
+					wget --timeout=5 -O 'debuerreotype.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeVersion}.tar.gz"
 					tar -xf debuerreotype.tgz --strip-components=1
 					if [ "$debuerreotypeExamplesCommit" != "$debuerreotypeVersion" ]; then
-						wget -O 'debuerreotype-examples.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeExamplesCommit}.tar.gz"
+						wget --timeout=5 -O 'debuerreotype-examples.tgz' "https://github.com/debuerreotype/debuerreotype/archive/${debuerreotypeExamplesCommit}.tar.gz"
 						rm -rf examples
 						tar -xf debuerreotype-examples.tgz --strip-components=1 \
 							"debuerreotype-${debuerreotypeExamplesCommit}/.docker-image.sh" \

--- a/tianon/docker-deb/arch-pipeline.groovy
+++ b/tianon/docker-deb/arch-pipeline.groovy
@@ -93,7 +93,7 @@ node(multiarchVars.node(env.BUILD_ARCH, 'sbuild')) { ansiColor('xterm') {
 						set -Eeuo pipefail
 						set -x
 
-						wget -O sources.zip "https://doi-janky.infosiftr.net/job/tianon/job/docker-deb/job/source/lastSuccessfulBuild/artifact/*_source.changes/*zip*/archive.zip"
+						wget --timeout=5 -O sources.zip "https://doi-janky.infosiftr.net/job/tianon/job/docker-deb/job/source/lastSuccessfulBuild/artifact/*_source.changes/*zip*/archive.zip"
 						unzip sources.zip
 						rm sources.zip
 					'

--- a/tianon/docker-deb/repo-pipeline.groovy
+++ b/tianon/docker-deb/repo-pipeline.groovy
@@ -20,7 +20,7 @@ node { ansiColor('xterm') {
 				stage(arch) {
 					sh '''
 						trap 'rm "$ARCH.zip"' EXIT
-						wget -O "$ARCH.zip" "https://doi-janky.infosiftr.net/job/tianon/job/docker-deb/job/$ARCH/lastSuccessfulBuild/artifact/**/*zip*/archive.zip" || exit 0
+						wget --timeout=5 -O "$ARCH.zip" "https://doi-janky.infosiftr.net/job/tianon/job/docker-deb/job/$ARCH/lastSuccessfulBuild/artifact/**/*zip*/archive.zip" || exit 0
 						unzip "$ARCH.zip"
 					'''
 				}

--- a/update.sh/target-pipeline.groovy
+++ b/update.sh/target-pipeline.groovy
@@ -350,7 +350,7 @@ node {
 					date="$(git -C repo log -1 --format='format:%aD')"
 					export GIT_AUTHOR_DATE="$date" GIT_COMMITTER_DATE="$date"
 					if [ "$BRANCH_BASE" = "$BRANCH_PUSH" ] && git -C oi add "$BASHBREW_LIBRARY/$repo" && git -C oi commit "${commitArgs[@]}"; then
-						if diff "$BASHBREW_LIBRARY/$repo" <(wget -qO- "$oiForkUrl/raw/$repo/library/$repo") &> /dev/null; then
+						if diff "$BASHBREW_LIBRARY/$repo" <(wget --timeout=5 -qO- "$oiForkUrl/raw/$repo/library/$repo") &> /dev/null; then
 							# if this exact file content is already pushed to a bot branch, don't force push it again
 							exit
 						fi

--- a/update.sh/versions-pipeline.groovy
+++ b/update.sh/versions-pipeline.groovy
@@ -300,7 +300,7 @@ node {
 				date="$(git -C repo log -1 --format='format:%aD')"
 				export GIT_AUTHOR_DATE="$date" GIT_COMMITTER_DATE="$date"
 				if [ "$BRANCH_BASE" = "$BRANCH_PUSH" ] && git -C oi add "$BASHBREW_LIBRARY/$repo" && git -C oi commit "${commitArgs[@]}"; then
-					if diff "$BASHBREW_LIBRARY/$repo" <(wget -qO- "$oiForkUrl/raw/$repo/library/$repo") &> /dev/null; then
+					if diff "$BASHBREW_LIBRARY/$repo" <(wget --timeout=5 -qO- "$oiForkUrl/raw/$repo/library/$repo") &> /dev/null; then
 						# if this exact file content is already pushed to a bot branch, don't force push it again
 						exit
 					fi


### PR DESCRIPTION
On `s390x` this `wget` is sporadically 2 seconds or 4.5 minutes. While the job was consistently taking 4.5 minutes per stage, I checked from the server and found that using IPv4 made the same `wget` fast again. This should hopefully prevent the ~10-12 minute job from taking over 5 hours. ~It will be admittedly a little slower than the ideal when `IPv6` is acting up since it has to hit the 5 second timeout. If the server doesn't have IPv6, then `ping` exits immediately non-zero: `ping: connect: Network is unreachable`. Since most of our servers don't have IPv6, it will apply to them but will be harmless.~ 

Successful Jenkins test:
```console
[Pipeline] { (alpine)
[Pipeline] withEnv
[Pipeline] {
[Pipeline] sh
++ wget --timeout=5 -qO- https://doi-janky.infosiftr.net/job/multiarch/job/s390x/job/alpine/lastSuccessfulBuild/artifact/build-info/commit.txt
+ commit=db306206035efb5cc4081fcc19d068e24ba6cb60
+ '[' -n db306206035efb5cc4081fcc19d068e24ba6cb60 ']'
++ git -C /mnt/docker/jenkins/doi-janky/s390x/workspace/multiarch/s390x/_trigger/oi/library log --oneline db306206035efb5cc4081fcc19d068e24ba6cb60...HEAD -- alpine
+ touchingCommits=
+ '[' -z '' ']'
````