### PR TITLE
Swap docker-library/meta subset references to main

### DIFF
--- a/multiarch/empty-pipeline.groovy
+++ b/multiarch/empty-pipeline.groovy
@@ -10,7 +10,7 @@ node {
 				url: 'https://github.com/docker-library/meta.git',
 				name: 'origin',
 			]],
-			branches: [[name: '*/subset']], // TODO back to main
+			branches: [[name: '*/main']],
 			extensions: [
 				submodule(
 					parentCredentials: true,

--- a/multiarch/generate-pipeline.groovy
+++ b/multiarch/generate-pipeline.groovy
@@ -52,9 +52,9 @@ node {
 		def archNamespaces = [:]
 		def archImages = [:]
 
-		// https://github.com/docker-library/meta/blob/subset/subset.txt
+		// https://github.com/docker-library/meta/blob/main/subset.txt
 		def subset = []
-		new URL('https://raw.githubusercontent.com/docker-library/meta/subset/subset.txt').eachLine { line ->
+		new URL('https://raw.githubusercontent.com/docker-library/meta/main/subset.txt').eachLine { line ->
 			subset << line
 		}
 		if (subset.size == 0) {


### PR DESCRIPTION
ref https://github.com/docker-library/meta-scripts/pull/85

Fixes failing "builds":
```console
Fetching changes from the remote Git repository
Cleaning workspace
ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
ERROR: Maximum checkout retry attempts reached, aborting
```