### PR TITLE
Add shasums for crane artifacts

### DIFF
--- a/wip/crane.groovy
+++ b/wip/crane.groovy
@@ -114,6 +114,19 @@ node {
 	}
 
 	dir('ggcr/bin') { stage('Archive') {
+		sh '''#!/usr/bin/env bash
+			set -Eeuo pipefail -x
+
+			sha256sum crane-* \
+			| jq --raw-input --null-input '
+				reduce (
+					inputs
+					| capture("(?<sha>[a-f0-9]+)  (?<name>[a-z0-9-]+)")
+				) as $i ({};
+					.[$i.name] = { sha256: $i.sha }
+				)
+			' > checksums.json
+		'''
 		archiveArtifacts(
 			artifacts: '**',
 			fingerprint: true,


### PR DESCRIPTION
Adding this so that we have some SHA sums to use from our AMI builder. Feel free to bike shed on the format of the json; this seemed good enough to give us a lookup table but might be overkill.

Tested via https://doi-janky.infosiftr.net/job/wip/job/crane/21/