### PR TITLE
Remove ghost update pipeline

### DIFF
--- a/update.sh/vars.groovy
+++ b/update.sh/vars.groovy
@@ -72,12 +72,6 @@ def rawReposData = [
 		'env': 'IRSSI_VERSION',
 	]],
 
-	// acburdine
-	['ghost', [
-		'url': 'git@github.com:TryGhost/docker-library-ghost.git',
-		'bot-branch': false,
-	]],
-
 	// pierreozoux
 	['matomo', [
 		'pipeline-script': 'update.sh/legacy-pipeline.groovy',


### PR DESCRIPTION
They've added their own update pipelines: https://github.com/TryGhost/docker-library-ghost/pull/473